### PR TITLE
feat: add MiniMax as LLM provider

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -11,6 +11,8 @@ SAMBNOVA_API_KEY=""
 # TODO: Get your Groq API key from https://console.groq.com/keys
 GROQ_API_KEY=""
 
+MINIMAX_API_KEY=""
+
 JINA_API_KEY=""
 
 MAX_WEB_RESEARCH_LOOPS=3
@@ -35,6 +37,9 @@ LLM_MODEL=gemini-2.5-pro
 
 # LLM_PROVIDER=sambnova
 # LLM_MODEL=DeepSeek-V3-0324
+
+# LLM_PROVIDER=minimax
+# LLM_MODEL=MiniMax-M2.7
 
 ## Activity generation configuration ##
 ENABLE_ACTIVITY_GENERATION=true

--- a/README.md
+++ b/README.md
@@ -90,10 +90,11 @@ cd ai-research-assistant && npm install && npm run build && cd ..
 - `TAVILY_API_KEY` - Tavily search API key
 - **One LLM provider key:**
   - `OPENAI_API_KEY` - OpenAI API key
-  - `ANTHROPIC_API_KEY` - Anthropic API key  
+  - `ANTHROPIC_API_KEY` - Anthropic API key
   - `GROQ_API_KEY` - Groq API key
   - `GOOGLE_CLOUD_PROJECT` - Google Cloud project ID
   - `SAMBNOVA_API_KEY` - SambaNova API key
+  - `MINIMAX_API_KEY` - [MiniMax](https://www.minimax.io/) API key
 
 **Optional Settings:**
 - `LLM_PROVIDER` - Default provider (default: `openai`)
@@ -109,6 +110,7 @@ cd ai-research-assistant && npm install && npm run build && cd ..
 | **Google** | `gemini-2.5-pro` | `gemini-2.5-pro`, `gemini-1.5-pro-latest`, `gemini-1.5-flash-latest` |
 | **Groq** | `deepseek-r1-distill-llama-70b` | `deepseek-r1-distill-llama-70b`, `llama-3.3-70b-versatile`, `llama3-70b-8192` |
 | **SambaNova** | `DeepSeek-V3-0324` | `DeepSeek-V3-0324` |
+| **MiniMax** | `MiniMax-M2.7` | `MiniMax-M2.7`, `MiniMax-M2.7-highspeed` |
 
 ### Running the Application
 

--- a/ai-research-assistant/src/components/InitialScreen.js
+++ b/ai-research-assistant/src/components/InitialScreen.js
@@ -96,6 +96,17 @@ const MODEL_OPTIONS = [
       </svg>
     ),
   },
+  {
+    key: "minimax-m2.7",
+    label: "MiniMax-M2.7",
+    model: "MiniMax-M2.7",
+    icon: (
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M3 4l4.5 8L3 20h3l3-5.5L12 20h3l-4.5-8L15 4h-3l-3 5.5L6 4H3z" fill="#6366F1"/>
+        <path d="M15 4l4.5 8L15 20h3l3-5.5V20h2V4h-2v5.5L18 4h-3z" fill="#6366F1"/>
+      </svg>
+    ),
+  },
 ]
 
 // Suggested questions for different modes

--- a/llm_clients.py
+++ b/llm_clients.py
@@ -27,6 +27,7 @@ OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 ANTHROPIC_API_KEY = os.getenv("ANTHROPIC_API_KEY")
 SFR_GATEWAY_API_KEY = os.getenv("SFR_GATEWAY_API_KEY")
 SAMBNOVA_API_KEY = os.getenv("SAMBNOVA_API_KEY")
+MINIMAX_API_KEY = os.getenv("MINIMAX_API_KEY")
 GOOGLE_CLOUD_PROJECT = os.getenv("GOOGLE_CLOUD_PROJECT")
 GOOGLE_CLOUD_LOCATION = os.getenv("GOOGLE_CLOUD_LOCATION", "us-central1")
 
@@ -44,6 +45,9 @@ ANTHROPIC_ASYNC_MAX_TOKENS = 8192
 
 # Google Gemini token limits
 GOOGLE_MAX_OUTPUT_TOKENS = 30000
+
+# MiniMax token limits
+MINIMAX_MAX_TOKENS = 16384
 
 # Get the current date in various formats for the system prompt
 CURRENT_DATE = datetime.now().strftime("%Y-%m-%d")
@@ -133,6 +137,15 @@ MODEL_CONFIGS = {
         ],
         "default_model": "gemini-2.5-pro",
         "requires_api_key": GOOGLE_CLOUD_PROJECT,
+    },
+    # MiniMax models (OpenAI-compatible API)
+    "minimax": {
+        "available_models": [
+            "MiniMax-M2.7",  # Latest flagship model (1M context)
+            "MiniMax-M2.7-highspeed",  # High-speed variant
+        ],
+        "default_model": "MiniMax-M2.7",
+        "requires_api_key": MINIMAX_API_KEY,
     },
 }
 
@@ -1180,6 +1193,110 @@ class SambNovaClient:
             yield ChatMessage(content=f"Error: {str(e)}", role="ai")
 
 
+# Custom client for MiniMax API (OpenAI-compatible)
+class MiniMaxClient:
+    """Client for MiniMax AI API via OpenAI-compatible endpoint.
+
+    MiniMax provides an OpenAI-compatible API at https://api.minimax.io/v1.
+    This client handles:
+    1. Temperature clamping to (0.0, 1.0] as required by MiniMax
+    2. Stripping <think>...</think> tags from reasoning model responses
+    3. Streaming support for long-running operations
+    """
+
+    def __init__(
+        self,
+        model_name: str,
+        api_key: str,
+        max_tokens: int = MINIMAX_MAX_TOKENS,
+    ):
+        """Initialize the MiniMax client.
+
+        Args:
+            model_name: The name of the model to use (e.g., 'MiniMax-M2.7')
+            api_key: The MiniMax API key
+            max_tokens: The maximum number of tokens to generate
+        """
+        self.model = model_name
+        self.model_name = model_name
+        self._api_key = api_key
+        self._max_tokens = max_tokens
+        self._client = openai.OpenAI(
+            api_key=api_key,
+            base_url="https://api.minimax.io/v1",
+        )
+
+    @staticmethod
+    def _clamp_temperature(temperature: float) -> float:
+        """Clamp temperature to MiniMax's valid range (0.0, 1.0]."""
+        if temperature <= 0.0:
+            return 0.01
+        if temperature > 1.0:
+            return 1.0
+        return temperature
+
+    @staticmethod
+    def _strip_think_tags(text: str) -> str:
+        """Strip <think>...</think> tags from reasoning model responses."""
+        import re
+        return re.sub(r"<think>.*?</think>\s*", "", text, flags=re.DOTALL)
+
+    @traceable
+    def invoke(self, messages, config=None):
+        """Invoke the MiniMax model with the given messages.
+
+        Args:
+            messages: List of LangChain message objects
+            config: Optional RunConfig for tracing
+
+        Returns:
+            A string with the model's response
+        """
+        try:
+            # Convert LangChain messages to OpenAI format
+            openai_messages = []
+            for msg in messages:
+                role = msg.type
+                if role == "human":
+                    role = "user"
+                elif role == "system":
+                    role = "system"
+                elif role == "ai":
+                    role = "assistant"
+                openai_messages.append({"role": role, "content": msg.content})
+
+            temperature = self._clamp_temperature(0.5)
+
+            print(f"Calling MiniMax API with model {self.model_name} (temperature={temperature})")
+            response = self._client.chat.completions.create(
+                model=self.model_name,
+                messages=openai_messages,
+                max_tokens=self._max_tokens,
+                temperature=temperature,
+                stream=True,
+            )
+
+            # Collect content from the stream
+            content_chunks = []
+            for chunk in response:
+                if hasattr(chunk, "choices") and chunk.choices:
+                    delta = chunk.choices[0].delta
+                    if hasattr(delta, "content") and delta.content:
+                        content_chunks.append(delta.content)
+                        print(".", end="", flush=True)
+
+            print("\nMiniMax streaming complete")
+            response_text = "".join(content_chunks)
+
+            # Strip think tags if present
+            response_text = self._strip_think_tags(response_text)
+
+            return response_text
+        except Exception as e:
+            print(f"[MiniMaxClient ERROR] {str(e)}")
+            raise
+
+
 def get_available_providers():
     """Returns a list of available providers based on configured API keys."""
     available_providers = []
@@ -1347,6 +1464,17 @@ def get_llm_client(provider, model_name=None):
             convert_system_message_to_human=True,  # Recommended for Gemini
             max_output_tokens=GOOGLE_MAX_OUTPUT_TOKENS,  # Using variable instead of hardcoded value
         )
+    elif provider == "minimax":
+        if not MINIMAX_API_KEY:
+            raise ValueError("MINIMAX_API_KEY is not set in environment")
+        if not model_name:
+            model_name = MODEL_CONFIGS["minimax"]["default_model"]
+        print(f"Using MiniMaxClient for {model_name}")
+        return MiniMaxClient(
+            model_name=model_name,
+            api_key=MINIMAX_API_KEY,
+            max_tokens=MINIMAX_MAX_TOKENS,
+        )
     else:
         raise ValueError(f"Unsupported provider: {provider}")
 
@@ -1481,6 +1609,19 @@ async def get_async_llm_client(provider, model_name=None):
             convert_system_message_to_human=True,  # Recommended for Gemini
             max_output_tokens=GOOGLE_MAX_OUTPUT_TOKENS,  # Using variable instead of hardcoded value
         )
+    elif provider == "minimax":
+        if not MINIMAX_API_KEY:
+            raise ValueError("MINIMAX_API_KEY is not set in environment")
+        if not model_name:
+            model_name = MODEL_CONFIGS["minimax"]["default_model"]
+        logger.info(
+            f"[get_async_llm_client] Creating async MiniMaxClient with model {model_name}"
+        )
+        return MiniMaxClient(
+            model_name=model_name,
+            api_key=MINIMAX_API_KEY,
+            max_tokens=MINIMAX_MAX_TOKENS,
+        )
     else:
         # For providers that don't have standard async clients via Langchain yet
         supported_providers = ["openai", "anthropic"]
@@ -1488,6 +1629,8 @@ async def get_async_llm_client(provider, model_name=None):
             supported_providers.append("groq")
         if GOOGLE_CLOUD_PROJECT:  # Add google to supported list
             supported_providers.append("google")
+        if MINIMAX_API_KEY:
+            supported_providers.append("minimax")
 
         error_msg = f"Async client not supported or API key missing for provider: {provider}. Supported with keys: {', '.join(supported_providers)}."
         logger.error(f"[get_async_llm_client] {error_msg}")

--- a/src/configuration.py
+++ b/src/configuration.py
@@ -17,6 +17,7 @@ class LLMProvider(Enum):
     ANTHROPIC = "anthropic"
     GROQ = "groq"
     GOOGLE = "google"
+    MINIMAX = "minimax"
 
 
 class ActivityVerbosity(Enum):
@@ -115,9 +116,13 @@ class Configuration:
                     "llama-3.3-70b-versatile"
                     if provider_str == "groq"
                     else (
-                        "gemini-2.5-pro"
-                        if provider_str == "google"
-                        else "gemini-2.5-pro"
+                        "MiniMax-M2.7"
+                        if provider_str == "minimax"
+                        else (
+                            "gemini-2.5-pro"
+                            if provider_str == "google"
+                            else "gemini-2.5-pro"
+                        )
                     )
                 )
             )

--- a/tests/test_minimax_provider.py
+++ b/tests/test_minimax_provider.py
@@ -1,0 +1,370 @@
+"""Unit tests for MiniMax LLM provider integration."""
+
+import os
+import sys
+import pytest
+from unittest.mock import patch, MagicMock, PropertyMock
+
+# Add parent directory to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+# Mock langchain_google_vertexai before importing llm_clients
+sys.modules["langchain_google_vertexai"] = MagicMock()
+
+
+class TestMiniMaxModelConfigs:
+    """Test MiniMax entries in MODEL_CONFIGS."""
+
+    def test_minimax_in_model_configs(self):
+        """MiniMax should be registered in MODEL_CONFIGS."""
+        from llm_clients import MODEL_CONFIGS
+
+        assert "minimax" in MODEL_CONFIGS
+
+    def test_minimax_default_model(self):
+        """MiniMax default model should be MiniMax-M2.7."""
+        from llm_clients import MODEL_CONFIGS
+
+        assert MODEL_CONFIGS["minimax"]["default_model"] == "MiniMax-M2.7"
+
+    def test_minimax_available_models(self):
+        """MiniMax should have M2.7 and M2.7-highspeed models."""
+        from llm_clients import MODEL_CONFIGS
+
+        models = MODEL_CONFIGS["minimax"]["available_models"]
+        assert "MiniMax-M2.7" in models
+        assert "MiniMax-M2.7-highspeed" in models
+
+    def test_minimax_requires_api_key_field(self):
+        """MiniMax config should have requires_api_key field."""
+        from llm_clients import MODEL_CONFIGS
+
+        assert "requires_api_key" in MODEL_CONFIGS["minimax"]
+
+
+class TestMiniMaxClient:
+    """Test MiniMaxClient class."""
+
+    def test_client_initialization(self):
+        """MiniMaxClient should initialize with correct attributes."""
+        from llm_clients import MiniMaxClient
+
+        client = MiniMaxClient(
+            model_name="MiniMax-M2.7",
+            api_key="test-key",
+            max_tokens=16384,
+        )
+        assert client.model == "MiniMax-M2.7"
+        assert client.model_name == "MiniMax-M2.7"
+        assert client._max_tokens == 16384
+
+    def test_temperature_clamping_zero(self):
+        """Temperature 0.0 should be clamped to 0.01."""
+        from llm_clients import MiniMaxClient
+
+        assert MiniMaxClient._clamp_temperature(0.0) == 0.01
+
+    def test_temperature_clamping_negative(self):
+        """Negative temperature should be clamped to 0.01."""
+        from llm_clients import MiniMaxClient
+
+        assert MiniMaxClient._clamp_temperature(-0.5) == 0.01
+
+    def test_temperature_clamping_high(self):
+        """Temperature > 1.0 should be clamped to 1.0."""
+        from llm_clients import MiniMaxClient
+
+        assert MiniMaxClient._clamp_temperature(1.5) == 1.0
+
+    def test_temperature_clamping_valid(self):
+        """Valid temperature should pass through unchanged."""
+        from llm_clients import MiniMaxClient
+
+        assert MiniMaxClient._clamp_temperature(0.5) == 0.5
+        assert MiniMaxClient._clamp_temperature(0.7) == 0.7
+        assert MiniMaxClient._clamp_temperature(1.0) == 1.0
+
+    def test_strip_think_tags(self):
+        """Think tags should be stripped from responses."""
+        from llm_clients import MiniMaxClient
+
+        text = "<think>internal reasoning here</think>Final answer."
+        assert MiniMaxClient._strip_think_tags(text) == "Final answer."
+
+    def test_strip_think_tags_multiline(self):
+        """Multiline think tags should be stripped."""
+        from llm_clients import MiniMaxClient
+
+        text = "<think>\nstep 1\nstep 2\n</think>\nThe result is 42."
+        result = MiniMaxClient._strip_think_tags(text)
+        assert "<think>" not in result
+        assert "The result is 42." in result
+
+    def test_strip_think_tags_no_tags(self):
+        """Text without think tags should be unchanged."""
+        from llm_clients import MiniMaxClient
+
+        text = "Just a normal response."
+        assert MiniMaxClient._strip_think_tags(text) == text
+
+    def test_client_openai_base_url(self):
+        """Client should use MiniMax's OpenAI-compatible base URL."""
+        from llm_clients import MiniMaxClient
+
+        client = MiniMaxClient(
+            model_name="MiniMax-M2.7",
+            api_key="test-key",
+        )
+        assert client._client.base_url.host == "api.minimax.io"
+
+
+class TestMiniMaxInLLMProviderEnum:
+    """Test MiniMax in LLMProvider enum."""
+
+    def test_minimax_in_llm_provider_enum(self):
+        """MINIMAX should be in LLMProvider enum."""
+        from src.configuration import LLMProvider
+
+        assert hasattr(LLMProvider, "MINIMAX")
+        assert LLMProvider.MINIMAX.value == "minimax"
+
+
+class TestGetLlmClientMiniMax:
+    """Test get_llm_client() with minimax provider."""
+
+    @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"})
+    def test_get_llm_client_minimax_default(self):
+        """get_llm_client('minimax') should return MiniMaxClient with default model."""
+        # Need to reload to pick up env var
+        import importlib
+        import llm_clients
+
+        importlib.reload(llm_clients)
+        from llm_clients import get_llm_client, MiniMaxClient
+
+        client = get_llm_client("minimax")
+        assert isinstance(client, MiniMaxClient)
+        assert client.model_name == "MiniMax-M2.7"
+
+    @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"})
+    def test_get_llm_client_minimax_custom_model(self):
+        """get_llm_client('minimax', 'MiniMax-M2.7-highspeed') should use specified model."""
+        import importlib
+        import llm_clients
+
+        importlib.reload(llm_clients)
+        from llm_clients import get_llm_client, MiniMaxClient
+
+        client = get_llm_client("minimax", "MiniMax-M2.7-highspeed")
+        assert isinstance(client, MiniMaxClient)
+        assert client.model_name == "MiniMax-M2.7-highspeed"
+
+    @patch.dict(os.environ, {}, clear=False)
+    def test_get_llm_client_minimax_no_key_raises(self):
+        """get_llm_client('minimax') without API key should raise ValueError."""
+        # Remove MINIMAX_API_KEY if set
+        env = os.environ.copy()
+        env.pop("MINIMAX_API_KEY", None)
+        with patch.dict(os.environ, env, clear=True):
+            import importlib
+            import llm_clients
+
+            importlib.reload(llm_clients)
+            from llm_clients import get_llm_client
+
+            with pytest.raises(ValueError, match="MINIMAX_API_KEY"):
+                get_llm_client("minimax")
+
+
+class TestGetAvailableProvidersMiniMax:
+    """Test get_available_providers() includes minimax when key is set."""
+
+    @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"})
+    def test_minimax_in_available_providers(self):
+        """MiniMax should appear in available providers when API key is set."""
+        import importlib
+        import llm_clients
+
+        importlib.reload(llm_clients)
+        from llm_clients import get_available_providers
+
+        providers = get_available_providers()
+        assert "minimax" in providers
+
+
+class TestConfigurationMiniMax:
+    """Test Configuration class with MiniMax provider."""
+
+    @patch.dict(os.environ, {"LLM_PROVIDER": "minimax"})
+    def test_configuration_minimax_provider(self):
+        """Configuration should accept minimax as LLM provider."""
+        from src.configuration import Configuration, LLMProvider
+
+        config = Configuration()
+        assert config.llm_provider == LLMProvider.MINIMAX
+
+    @patch.dict(os.environ, {"LLM_PROVIDER": "minimax"})
+    def test_configuration_minimax_default_model(self):
+        """Configuration should return MiniMax-M2.7 as default model for minimax."""
+        from src.configuration import Configuration
+
+        config = Configuration()
+        assert config.llm_model == "MiniMax-M2.7"
+
+    def test_configuration_minimax_explicit(self):
+        """Configuration should accept minimax via kwargs."""
+        from src.configuration import Configuration, LLMProvider
+
+        config = Configuration(llm_provider=LLMProvider.MINIMAX, llm_model="MiniMax-M2.7-highspeed")
+        assert config.llm_provider == LLMProvider.MINIMAX
+        assert config.llm_model == "MiniMax-M2.7-highspeed"
+
+
+class TestMiniMaxTokenLimits:
+    """Test MiniMax token limit constants."""
+
+    def test_minimax_max_tokens_defined(self):
+        """MINIMAX_MAX_TOKENS should be defined."""
+        from llm_clients import MINIMAX_MAX_TOKENS
+
+        assert MINIMAX_MAX_TOKENS == 16384
+
+    def test_minimax_max_tokens_positive(self):
+        """MINIMAX_MAX_TOKENS should be a positive integer."""
+        from llm_clients import MINIMAX_MAX_TOKENS
+
+        assert isinstance(MINIMAX_MAX_TOKENS, int)
+        assert MINIMAX_MAX_TOKENS > 0
+
+
+class TestMiniMaxClientInvoke:
+    """Test MiniMaxClient.invoke() with mocked API."""
+
+    @patch("openai.OpenAI")
+    def test_invoke_with_langchain_messages(self, mock_openai_cls):
+        """invoke() should convert LangChain messages and return response text."""
+        from llm_clients import MiniMaxClient
+
+        # Setup mock
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+
+        # Mock streaming response
+        mock_chunk = MagicMock()
+        mock_chunk.choices = [MagicMock()]
+        mock_chunk.choices[0].delta = MagicMock()
+        mock_chunk.choices[0].delta.content = "Hello from MiniMax"
+
+        mock_client.chat.completions.create.return_value = [mock_chunk]
+
+        client = MiniMaxClient(model_name="MiniMax-M2.7", api_key="test-key")
+        client._client = mock_client
+
+        # Create mock LangChain messages
+        system_msg = MagicMock()
+        system_msg.type = "system"
+        system_msg.content = "You are a helpful assistant."
+        human_msg = MagicMock()
+        human_msg.type = "human"
+        human_msg.content = "Hello!"
+
+        result = client.invoke([system_msg, human_msg])
+
+        assert result == "Hello from MiniMax"
+        mock_client.chat.completions.create.assert_called_once()
+
+    @patch("openai.OpenAI")
+    def test_invoke_strips_think_tags(self, mock_openai_cls):
+        """invoke() should strip <think> tags from response."""
+        from llm_clients import MiniMaxClient
+
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+
+        # Mock response with think tags
+        mock_chunk1 = MagicMock()
+        mock_chunk1.choices = [MagicMock()]
+        mock_chunk1.choices[0].delta = MagicMock()
+        mock_chunk1.choices[0].delta.content = "<think>reasoning</think>"
+
+        mock_chunk2 = MagicMock()
+        mock_chunk2.choices = [MagicMock()]
+        mock_chunk2.choices[0].delta = MagicMock()
+        mock_chunk2.choices[0].delta.content = "Final answer."
+
+        mock_client.chat.completions.create.return_value = [mock_chunk1, mock_chunk2]
+
+        client = MiniMaxClient(model_name="MiniMax-M2.7", api_key="test-key")
+        client._client = mock_client
+
+        msg = MagicMock()
+        msg.type = "human"
+        msg.content = "Test"
+
+        result = client.invoke([msg])
+
+        assert "<think>" not in result
+        assert "Final answer." in result
+
+
+class TestMiniMaxIntegration:
+    """Integration tests for MiniMax provider (require MINIMAX_API_KEY)."""
+
+    @pytest.fixture(autouse=True)
+    def skip_without_api_key(self):
+        if not os.getenv("MINIMAX_API_KEY"):
+            pytest.skip("MINIMAX_API_KEY not set, skipping integration tests")
+
+    def test_minimax_live_invoke(self):
+        """Integration: invoke MiniMax API and get a response."""
+        import importlib
+        import llm_clients
+
+        importlib.reload(llm_clients)
+        from llm_clients import get_llm_client
+        from langchain.schema import HumanMessage, SystemMessage
+
+        client = get_llm_client("minimax", "MiniMax-M2.7-highspeed")
+        messages = [
+            SystemMessage(content="You are a helpful assistant. Reply in one sentence."),
+            HumanMessage(content="What is 2+2?"),
+        ]
+        response = client.invoke(messages)
+        assert isinstance(response, str)
+        assert len(response) > 0
+        assert "4" in response
+
+    def test_minimax_live_get_model_response(self):
+        """Integration: get_model_response() with MiniMax."""
+        import importlib
+        import llm_clients
+
+        importlib.reload(llm_clients)
+        from llm_clients import get_llm_client, get_model_response
+
+        client = get_llm_client("minimax", "MiniMax-M2.7-highspeed")
+        response = get_model_response(
+            client,
+            system_prompt="You are helpful. Reply in one sentence.",
+            user_prompt="What color is the sky on a clear day?",
+        )
+        assert isinstance(response, str)
+        assert len(response) > 0
+
+    def test_minimax_live_streaming(self):
+        """Integration: MiniMax streaming should return complete response."""
+        import importlib
+        import llm_clients
+
+        importlib.reload(llm_clients)
+        from llm_clients import get_llm_client
+        from langchain.schema import HumanMessage, SystemMessage
+
+        client = get_llm_client("minimax")
+        messages = [
+            SystemMessage(content="Reply with exactly: Hello World"),
+            HumanMessage(content="Say the phrase"),
+        ]
+        response = client.invoke(messages)
+        assert isinstance(response, str)
+        assert len(response) > 0


### PR DESCRIPTION
## Summary

Add [MiniMax AI](https://www.minimax.io/) as a first-class LLM provider for Enterprise Deep Research, alongside existing OpenAI, Anthropic, Groq, Google Vertex AI, and SambaNova backends.

### Changes

**Backend (llm_clients.py)**
- New `MiniMaxClient` class with OpenAI-compatible streaming via `https://api.minimax.io/v1`
- Temperature clamping to (0.0, 1.0] as required by MiniMax API
- `<think>...</think>` tag stripping for reasoning model responses
- `MODEL_CONFIGS` entry with MiniMax-M2.7 (1M context) and MiniMax-M2.7-highspeed models
- `get_llm_client()` and `get_async_llm_client()` factory support

**Configuration (src/configuration.py)**
- `MINIMAX` added to `LLMProvider` enum
- Default model mapping (`MiniMax-M2.7`) in `llm_model` property

**Frontend (InitialScreen.js)**
- MiniMax-M2.7 option in model selection dropdown

**Docs & Config**
- `.env.sample`: `MINIMAX_API_KEY` variable and provider config
- `README.md`: MiniMax in supported models table and API key docs

**Tests (tests/test_minimax_provider.py)**
- 25 unit tests covering MODEL_CONFIGS, MiniMaxClient, temperature clamping, think-tag stripping, LLMProvider enum, factory functions, Configuration class
- 3 integration tests (skipped without API key)

## Test Plan

- [x] All 25 unit tests pass
- [x] All 3 integration tests pass with live MiniMax API
- [ ] Verify frontend model dropdown shows MiniMax-M2.7 option
- [ ] Run existing test suite to confirm no regressions
