### PR TITLE
Fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,11 +191,11 @@ enterprise-deep-research/
 ```
 ## Star History
 
-<a href="https://www.star-history.com/#SalesforceAIResearch/enterprise-deep-research&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#SalesforceAIResearch/enterprise-deep-research&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=SalesforceAIResearch/enterprise-deep-research&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=SalesforceAIResearch/enterprise-deep-research&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=SalesforceAIResearch/enterprise-deep-research&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=SalesforceAIResearch/enterprise-deep-research&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=SalesforceAIResearch/enterprise-deep-research&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=SalesforceAIResearch/enterprise-deep-research&type=date&legend=top-left" />
  </picture>
 </a>
 


### PR DESCRIPTION
The star history chart in the README is currently broken and does not render. This change points the chart to a working endpoint so the repository's star history is displayed correctly again.

This is a small documentation fix with no impact on functionality.